### PR TITLE
 Got rid of unnecessary span usage within the 'return' buttons on ever…

### DIFF
--- a/src/pages/Compare.svelte
+++ b/src/pages/Compare.svelte
@@ -103,6 +103,7 @@
         align-items: center;
     }
     button{
+        margin-top: 1rem;
         margin-left: 1rem;
         font-weight: bold;
         position: relative;
@@ -127,7 +128,7 @@
 
 
 {#if activeComparison}
-<button on:click={()=>{ resetPage()}}><span>⬅ </span>Return to Comparisons</button>
+<button on:click={()=>{ resetPage()}}>⬅ Return to Comparisons</button>
 {/if}
 {#if !activeComparison}
 <h1>Compare:</h1>

--- a/src/pages/Create.svelte
+++ b/src/pages/Create.svelte
@@ -158,20 +158,20 @@
         padding-left: 1rem;
         text-decoration: underline;
     }
+
     #main{
         display: flex;
         flex-direction: row;
     }
    
     #form-box{
-        margin-top: 2rem; 
         margin-bottom: 1rem;
         padding-left: 5.2rem;
         font-family: 'Solway', serif;
         width: 25%;
     }
     #form-box>h2{
-        padding-left: 1rem;
+        margin-bottom: 0;
     }
     .submit-button{
         padding: 0;
@@ -256,9 +256,10 @@
         font-size: 1.25rem;
     }
      #reset-button{
+        margin-top: 1rem;
         margin-left: 1rem;
         font-weight: bold;
-        width: 18%;
+        width: 15%;
         height: 2.3rem;
         background-color: #ca464638;
         border-radius: 15px;
@@ -270,9 +271,11 @@
         color: white;
     }
 </style>
+{#if !selectedLanguages}
 <h1>Create:</h1>
+{/if}
 {#if selectedLanguages}
-<button id="reset-button" on:click={()=>{resetAllVariables()}}>Make A New Language</button>
+<button id="reset-button" on:click={()=>{resetAllVariables()}}>⬅ Make A New Language</button>
 {/if}
 <div id = "main">
     <div id = "form-box">

--- a/src/pages/Explore.svelte
+++ b/src/pages/Explore.svelte
@@ -58,6 +58,7 @@
         height: 6rem;
     }
       button{
+          margin-top: 1rem;
         margin-left: 1rem;
         font-weight: bold;
         position: relative;
@@ -80,7 +81,7 @@
 
 
 {#if selectedLanguage}
-<button on:click={()=>{resetPage()}}><span>⬅ </span>Return to Languages</button>
+<button on:click={()=>{resetPage()}}>⬅ Return to Languages</button>
 {/if}
 {#if !selectedLanguage}
 <h1>Explore:</h1>


### PR DESCRIPTION
…y page. The arrow that was contained in the buttons is now directly in the button text rather than its own span. Also added a top-margin to buttons to get it further away from the header logo