### PR TITLE
Added in notes on how to reorganize components once dictionary backend…

### DIFF
--- a/src/pages/grammars/German.svelte
+++ b/src/pages/grammars/German.svelte
@@ -19,7 +19,8 @@ const adjectives = dictionary.adjectives;
 // }
 
 
-// There's a ton of cases markers in German, come back if figuring out a more concide way of doing this
+// These are now being-built into back end - and will come up when the callis made so can be deleted once 
+// the backend is fully up an running
 const mascDet = [{original: "Nominative"},{original: "Accusative"},{original: "Dative"},
 {original: "Genitive"},];
 

--- a/src/pages/tables/GermanGrammarTable.svelte
+++ b/src/pages/tables/GermanGrammarTable.svelte
@@ -8,6 +8,7 @@
     // restructure pronouns so that it's by person rather than case, so that this can be component
 
 </script>
+<!-- DELETE THIS COMPONENT ONCE DICTIONARY BACKEND IS LINKED- AND MOVE THIS TABLE TO THE CONJUGATION TABLE COMPONENT -->
 
 
 <style>


### PR DESCRIPTION
… in linked up later this week- it will greatly reduce amount of front end variables/ hand typed out dictionaries, and allow for the use of more general components like the conjugationTable, rather than having to make new ones like with GermanCase Row